### PR TITLE
Update MysqlDriver.php

### DIFF
--- a/lib/MongoSql/Driver/MysqlDriver.php
+++ b/lib/MongoSql/Driver/MysqlDriver.php
@@ -71,7 +71,7 @@ class MysqlDriver extends Driver
         // See https://mariadb.atlassian.net/browse/MDEV-4088
         // Note that query `SELECT VERSION()` won't return MySQL copat prefix
         if (strpos($currentVersion, '-MariaDB') !== false) {
-            [$mySqlCompatVersion, $mariaDbVersion] = explode('-', $currentVersion, 2);
+            [$mariaDbVersion, $mySqlCompatVersion] = explode('-', $currentVersion, 2);
 
             $currentVersion = $mariaDbVersion;
             $minVersion = static::DB_MIN_SERVER_VERSION_MARIADB;


### PR DESCRIPTION
The installation error log told me that the current version of MariaDB that I'm using wasn't matching with the minimum version, however, it wasn't comparing it to a version that I'm using but instead it was comparing the minimum version to a string of "MariaDB". On line 74, I switched the variables around in the array brackets when the explode function returned the list of strings. Once the change was made, the installation went successfully.